### PR TITLE
add masking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 __pycache__/
 .ipynb_checkpoints/
 log/
+*.txt
+sinfo

--- a/src/layers/BiMinGRU.py
+++ b/src/layers/BiMinGRU.py
@@ -9,10 +9,11 @@ class BiMinGRU(nn.Module):
     self.backward_rnn = MinGRU(dim_in, dim_hidden)
     self.linear = nn.Linear(2 * dim_hidden, dim_hidden)
   
-  def forward(self, x):
+  def forward(self, x, mask):
     x_reversed = x.flip(dims=[1])
+    mask_reversed = mask.flip(dims=[1])
     out_forward = self.forward_rnn(x)
-    out_backward = self.backward_rnn(x_reversed)
+    out_backward = self.backward_rnn(x_reversed, mask_reversed)
     concat = torch.cat((out_forward, out_backward), dim=2)
     out = self.linear(concat)
 

--- a/src/layers/BiMinGRU.py
+++ b/src/layers/BiMinGRU.py
@@ -14,7 +14,7 @@ class BiMinGRU(nn.Module):
     mask_reversed = mask.flip(dims=[1])
     out_forward = self.forward_rnn(x)
     out_backward = self.backward_rnn(x_reversed, mask_reversed)
-    concat = torch.cat((out_forward, out_backward), dim=2)
+    concat = torch.cat((out_forward, out_backward.flip(dims=[1])), dim=2)
     out = self.linear(concat)
 
     return out

--- a/src/layers/BiMinGRU.py
+++ b/src/layers/BiMinGRU.py
@@ -2,19 +2,20 @@ import torch
 from torch import nn
 from layers.MinGRU import MinGRU
 
-class BiMinGRU(nn.Module):
-  def __init__(self, dim_in, dim_hidden):
-    super().__init__()
-    self.forward_rnn = MinGRU(dim_in, dim_hidden)
-    self.backward_rnn = MinGRU(dim_in, dim_hidden)
-    self.linear = nn.Linear(2 * dim_hidden, dim_hidden)
-  
-  def forward(self, x, mask):
-    x_reversed = x.flip(dims=[1])
-    mask_reversed = mask.flip(dims=[1])
-    out_forward = self.forward_rnn(x)
-    out_backward = self.backward_rnn(x_reversed, mask_reversed)
-    concat = torch.cat((out_forward, out_backward.flip(dims=[1])), dim=2)
-    out = self.linear(concat)
 
-    return out
+class BiMinGRU(nn.Module):
+    def __init__(self, dim_in, dim_hidden):
+        super().__init__()
+        self.forward_rnn = MinGRU(dim_in, dim_hidden)
+        self.backward_rnn = MinGRU(dim_in, dim_hidden)
+        self.linear = nn.Linear(2 * dim_hidden, dim_hidden)
+
+    def forward(self, x, mask):
+        x_reversed = x.flip(dims=[1])
+        mask_reversed = mask.flip(dims=[1])
+        out_forward = self.forward_rnn(x, mask=mask)
+        out_backward = self.backward_rnn(x_reversed, mask=mask_reversed)
+        concat = torch.cat((out_forward, out_backward.flip(dims=[1])), dim=2)
+        out = self.linear(concat)
+
+        return out

--- a/src/layers/MinGRU.py
+++ b/src/layers/MinGRU.py
@@ -44,7 +44,7 @@ class MinGRU(nn.Module):
         """
         return torch.where(x >= 0, torch.log(F.relu(x)+0.5), -F.softplus(-x))
 
-    def forward(self, x, h_prev=None, mask=None):
+    def forward(self, x, *, h_prev=None, mask=None):
         """
         Compute the forward pass. Note that if h_prev is not none,
         then we assume the model is processing tokens sequentially.
@@ -80,9 +80,10 @@ class MinGRU(nn.Module):
 
             if mask is not None:
                 mask = mask.unsqueeze(-1)
-                log_z = log_z.masked_fill(mask, 0)
-                log_tilde_h = log_tilde_h.masked_fill(mask, 0)
-                log_one_minus_z = log_one_minus_z.masked_fill(mask, 0)
+                log_z = log_z.masked_fill(mask, float('-inf'))
+                log_tilde_h = log_tilde_h.masked_fill(mask, float('-inf'))
+                log_one_minus_z = log_one_minus_z.masked_fill(
+                    mask, float('-inf'))
 
             h = self.parallel_scan_log(
                 log_one_minus_z, log_z + log_tilde_h)  # Hidden states

--- a/src/layers/MinGRU.py
+++ b/src/layers/MinGRU.py
@@ -74,12 +74,12 @@ class MinGRU(nn.Module):
             log_z = -F.softplus(-k) # Log (z)
             log_one_minus_z = -F.softplus(k) # Log (1 - z)
             log_tilde_h = self.log_g(tilde_h) # Log candidate state
-            h = self.parallel_scan_log(log_one_minus_z, log_z + log_tilde_h) # Hidden states
 
-            if mask is not None:
-                mask = mask.unsqueeze(-1) # [batch_size, seq_len, 1]
-                # NOTE: because minGRU computes hidden states sequentially (unlike attention)
-                #       if suffices to mask out the irrelevant hidden states to 0
-                h = h.masked_fill(mask, 0)
+            mask = mask.unsqueeze(-1)
+            log_one_minus_z = h.masked_fill(mask, 0)
+            log_tilde_h = h.masked_fill(mask, 0)
+            log_one_minus_z = h.masked_fill(mask, 0)
+
+            h = self.parallel_scan_log(log_one_minus_z, log_z + log_tilde_h) # Hidden states
 
         return h

--- a/src/layers/MinGRU.py
+++ b/src/layers/MinGRU.py
@@ -2,11 +2,14 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
+
 class MinGRU(nn.Module):
     def __init__(self, dim_in, dim_hidden):
         super().__init__()
-        self.linear_z = nn.Linear(dim_in, dim_hidden) # Linear layer for producing z from x
-        self.linear_h = nn.Linear(dim_in, dim_hidden) # Linear layer for producing candidate state h_tilde from x
+        # Linear layer for producing z from x
+        self.linear_z = nn.Linear(dim_in, dim_hidden)
+        # Linear layer for producing candidate state h_tilde from x
+        self.linear_h = nn.Linear(dim_in, dim_hidden)
 
     def parallel_scan_log(self, log_a, log_b):
         """
@@ -61,25 +64,27 @@ class MinGRU(nn.Module):
             h: torch.Tensor [batch_size, seq_len, dim_hidden]
         """
         k = self.linear_z(x)
-        tilde_h = self.linear_h(x) # Candidate state
+        tilde_h = self.linear_h(x)  # Candidate state
 
-        if h_prev is not None: # Sequential mode
+        if h_prev is not None:  # Sequential mode
             assert x.shape[1] == 1
             z = torch.sigmoid(k)
             tilde_h = self.g(tilde_h)
-            h = (1 - z) * h_prev + z * tilde_h # h[t]
-        else: # Parallel Mode
+            h = (1 - z) * h_prev + z * tilde_h  # h[t]
+        else:  # Parallel Mode
             # NOTE: the implementation provided in the paper allows providing an explicit
             #       starting state h_0; we fix h_0 (implicitly) to be zero initialized
-            log_z = -F.softplus(-k) # Log (z)
-            log_one_minus_z = -F.softplus(k) # Log (1 - z)
-            log_tilde_h = self.log_g(tilde_h) # Log candidate state
+            log_z = -F.softplus(-k)  # Log (z)
+            log_one_minus_z = -F.softplus(k)  # Log (1 - z)
+            log_tilde_h = self.log_g(tilde_h)  # Log candidate state
 
-            mask = mask.unsqueeze(-1)
-            log_z = log_z.masked_fill(mask, 0)
-            log_tilde_h = log_tilde_h.masked_fill(mask, 0)
-            log_one_minus_z = log_one_minus_z.masked_fill(mask, 0)
+            if mask is not None:
+                mask = mask.unsqueeze(-1)
+                log_z = log_z.masked_fill(mask, 0)
+                log_tilde_h = log_tilde_h.masked_fill(mask, 0)
+                log_one_minus_z = log_one_minus_z.masked_fill(mask, 0)
 
-            h = self.parallel_scan_log(log_one_minus_z, log_z + log_tilde_h) # Hidden states
+            h = self.parallel_scan_log(
+                log_one_minus_z, log_z + log_tilde_h)  # Hidden states
 
         return h

--- a/src/layers/MinGRU.py
+++ b/src/layers/MinGRU.py
@@ -80,12 +80,14 @@ class MinGRU(nn.Module):
 
             if mask is not None:
                 mask = mask.unsqueeze(-1)
-                log_z = log_z.masked_fill(mask, float('-inf'))
-                log_tilde_h = log_tilde_h.masked_fill(mask, float('-inf'))
+                log_z = log_z.masked_fill(mask, 0)
+                log_tilde_h = log_tilde_h.masked_fill(mask, 0)
                 log_one_minus_z = log_one_minus_z.masked_fill(
-                    mask, float('-inf'))
+                    mask, 0)
 
             h = self.parallel_scan_log(
                 log_one_minus_z, log_z + log_tilde_h)  # Hidden states
 
+            if mask is not None:
+                h = h.masked_fill(mask, 0)
         return h

--- a/src/layers/MinGRU.py
+++ b/src/layers/MinGRU.py
@@ -76,9 +76,9 @@ class MinGRU(nn.Module):
             log_tilde_h = self.log_g(tilde_h) # Log candidate state
 
             mask = mask.unsqueeze(-1)
-            log_one_minus_z = h.masked_fill(mask, 0)
-            log_tilde_h = h.masked_fill(mask, 0)
-            log_one_minus_z = h.masked_fill(mask, 0)
+            log_z = log_z.masked_fill(mask, 0)
+            log_tilde_h = log_tilde_h.masked_fill(mask, 0)
+            log_one_minus_z = log_one_minus_z.masked_fill(mask, 0)
 
             h = self.parallel_scan_log(log_one_minus_z, log_z + log_tilde_h) # Hidden states
 


### PR DESCRIPTION
There are two cases we need to handle: Prepadding (PAD, PAD, ... , X1, ...) & postpadding (X1, ..., PAD, PAD).

In SQUAD, post-padding will correspond to the forward layer in the bidirectional MinGRU, and pre-padding will correspond to the backward layer.

After applying masking, a[i] = b[i] = 0 for padded tokens at index i regardless of whether we are doing pre or postpadding, and therefore h[i] = 0 as well. Crucially, in prepadding, the hidden states of the actual tokens will not be influenced by the hidden states of the padded tokens.

Then, in BiMinGRU, we ensure that we are also flipping the mask, so that it lines up with the padded tokens in the reversed case.

Since h[I] = 0 for all padded tokens, we ensure that they never contribute to the hidden states of the actual tokens


