### PR TITLE
Add test for BiMinGRU batched forward

### DIFF
--- a/src/layers/BiMinGRU.py
+++ b/src/layers/BiMinGRU.py
@@ -10,9 +10,9 @@ class BiMinGRU(nn.Module):
         self.backward_rnn = MinGRU(dim_in, dim_hidden)
         self.linear = nn.Linear(2 * dim_hidden, dim_hidden)
 
-    def forward(self, x, mask):
+    def forward(self, x, mask=None):
         x_reversed = x.flip(dims=[1])
-        mask_reversed = mask.flip(dims=[1])
+        mask_reversed = mask.flip(dims=[1]) if mask is not None else None
         out_forward = self.forward_rnn(x, mask=mask)
         out_backward = self.backward_rnn(x_reversed, mask=mask_reversed)
         concat = torch.cat((out_forward, out_backward.flip(dims=[1])), dim=2)

--- a/tests/test_BiMinGRU.py
+++ b/tests/test_BiMinGRU.py
@@ -1,0 +1,29 @@
+import torch
+from layers.BiMinGRU import BiMinGRU
+
+
+class TestBiMinGRU:
+    def test_batched_forward(self):
+        batch_size, hidden_size = 2, 10
+        seq1_len, seq2_len = 10, 6
+        layer = BiMinGRU(hidden_size, hidden_size)
+        x = torch.randn((batch_size, seq1_len, hidden_size))
+
+        # compute batched
+        mask = torch.zeros((batch_size, seq1_len))
+        mask[1,seq2_len:] = 1
+        mask = mask.bool()
+        o = layer(x, mask)
+        assert o.shape == (batch_size, seq1_len, hidden_size)
+        seq1_hidden_batched, seq2_hidden_batched = o[0][:seq1_len], o[1][:seq2_len]
+
+        # compute sequential
+        seq1 = x[0][:seq1_len].unsqueeze(0)
+        seq2 = x[1][:seq2_len].unsqueeze(0)
+        seq1_hidden_sequential = layer(seq1)[0]
+        seq2_hidden_sequential = layer(seq2)[0]
+
+        assert seq1_hidden_sequential.shape == seq1_hidden_batched.shape == (seq1_len, hidden_size)
+        assert seq2_hidden_sequential.shape == seq2_hidden_batched.shape == (seq2_len, hidden_size)
+        assert torch.allclose(seq1_hidden_batched, seq1_hidden_sequential)
+        assert torch.allclose(seq2_hidden_batched, seq2_hidden_sequential)


### PR DESCRIPTION
Test fails with
```
E        +  where False = <built-in method allclose of type object at 0x104ebb770>(tensor([[ 0.4199,  0.0057,  0.3358, -0.1086, -0.5924,  0.2753, -0.4912, -0.5759,\n         -0.3490, -0.3767],\n        [...,  0.0327,  0.9413, -0.9194, -1.3329,  0.6925, -1.0425, -1.5358,\n         -1.5268, -0.7941]], grad_fn=<SliceBackward0>), tensor([[ 0.4026, -0.0207,  0.2967, -0.0501, -0.5500,  0.3178, -0.4913, -0.5604,\n         -0.3552, -0.3129],\n        [...  0.0452,  0.3707,  0.2349, -0.5991,  0.2730,  0.1151, -0.7067,\n         -0.7941,  0.0976]], grad_fn=<SelectBackward0>))
E        +    where <built-in method allclose of type object at 0x104ebb770> = torch.allclose
```

+ masking using -inf leads to `nan` values as expected, so that is not the correct fix