### PR TITLE
Profiling Training Loop

### DIFF
--- a/src/utils/squad_dataloader.py
+++ b/src/utils/squad_dataloader.py
@@ -65,10 +65,15 @@ def preprocess_function(tokenizer, examples):
     return inputs
 
 
-def get_squad_v2_dataloaders(tokenizer, batch_size):
+def get_squad_v2_dataloaders(tokenizer, batch_size, num_examples=None):
     # Load datasets from HuggingFace
     train_dataset = load_dataset("rajpurkar/squad_v2", split="train")
     val_dataset = load_dataset("rajpurkar/squad_v2", split="validation")
+
+    # selects a subset of examples, if arg is specified 
+    if num_examples is not None:
+        train_dataset = train_dataset.select(range(num_examples))
+        val_dataset = val_dataset.select(range(num_examples))
 
     # Preprocess and tokenize
     cols_to_remove = set(train_dataset.column_names)
@@ -104,8 +109,12 @@ def get_squad_v2_dataloaders(tokenizer, batch_size):
     return train_dataloader, val_dataloader
 
 
-def get_squad_v2_validation_references():
+def get_squad_v2_validation_references(num_examples=None):
     val_dataset = load_dataset("rajpurkar/squad_v2", split="validation")
+
+    if num_examples is not None:
+      val_dataset = val_dataset.select(range(num_examples))
+
     # Remove everything except id and answers
     cols_to_remove = val_dataset.column_names
     cols_to_remove.remove("id")

--- a/src/utils/squad_dataloader.py
+++ b/src/utils/squad_dataloader.py
@@ -72,8 +72,8 @@ def get_squad_v2_dataloaders(tokenizer, batch_size, num_examples=None):
 
     # selects a subset of examples, if arg is specified 
     if num_examples is not None:
-        train_dataset = train_dataset.select(range(num_examples))
-        val_dataset = val_dataset.select(range(num_examples))
+        train_dataset = train_dataset.select(range(int(0.8*num_examples)))
+        val_dataset = val_dataset.select(range(int(0.2*num_examples)))
 
     # Preprocess and tokenize
     cols_to_remove = set(train_dataset.column_names)
@@ -108,12 +108,11 @@ def get_squad_v2_dataloaders(tokenizer, batch_size, num_examples=None):
 
     return train_dataloader, val_dataloader
 
-
 def get_squad_v2_validation_references(num_examples=None):
     val_dataset = load_dataset("rajpurkar/squad_v2", split="validation")
 
     if num_examples is not None:
-      val_dataset = val_dataset.select(range(num_examples))
+      val_dataset = val_dataset.select(range(int(0.2*num_examples)))
 
     # Remove everything except id and answers
     cols_to_remove = val_dataset.column_names

--- a/train_squad.py
+++ b/train_squad.py
@@ -36,20 +36,12 @@ elif hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
     device = "mps" # apple silicon
 print(f"Using device: {device}")
 
-"""
 # Optimizer configurations
 max_lr = 6e-4 * 3
 min_lr = max_lr * 0.1
 warmup_steps = 5000
 epochs = 30
 B = 16 # batch size
-
-"""
-# Testing configs
-max_lr = 1e-3 
-min_lr = max_lr * 0.1
-epochs = 10
-B = 10 
 
 # Model configurations
 n_layer = 2
@@ -74,13 +66,9 @@ print(f"Model size: {model_size} parameters")
 model.to(device)
 
 # num examples could be set here if needed for debugging 
-NUM_EXAMPLES = 1000
-train_loader, val_loader = get_squad_v2_dataloaders(tokenizer, batch_size=B, num_examples=NUM_EXAMPLES)
-references = get_squad_v2_validation_references(num_examples=NUM_EXAMPLES)
-"""
 train_loader, val_loader = get_squad_v2_dataloaders(tokenizer, batch_size=B)
 references = get_squad_v2_validation_references()
-"""
+
 squad_metric = load("squad_v2")
 if use_compile:
     model = torch.compile(model)
@@ -95,9 +83,6 @@ eval_every = 5 # Every n epochs, evaluate EM and F1
 
 optimizer = torch.optim.AdamW(model.parameters(), lr=1e-4, fused=use_fused)
 num_training_steps = epochs * len(train_loader)  # Total number of steps
-
-#remove if set before
-warmup_steps = int(0.1 * num_training_steps)
 
 scheduler = get_cosine_schedule_with_warmup(optimizer, num_warmup_steps=warmup_steps, num_training_steps=num_training_steps)
 


### PR DESCRIPTION
Modified squad_dataloader to optionally select a subset of examples for debugging 
Added profiling for memory and flops using torch profiler (this should work on custom models built on top of the torch.nn.Module and torch operations)

TO DO: verify if profiling works for minGRU