### PR TITLE
Unidirectional Min GRU

### DIFF
--- a/src/layers/rnn/BiMinGRU.py
+++ b/src/layers/rnn/BiMinGRU.py
@@ -10,11 +10,11 @@ class BiMinGRU(nn.Module):
         self.backward_rnn = MinGRU(dim_in, dim_hidden)
         self.linear = nn.Linear(2 * dim_hidden, dim_hidden)
 
-    def forward(self, x, mask=None, is_sequential=False):
+    def forward(self, x, mask=None):
         x_reversed = x.flip(dims=[1])
         mask_reversed = mask.flip(dims=[1]) if mask is not None else None
-        out_forward = self.forward_rnn(x, mask=mask, is_sequential=is_sequential)
-        out_backward = self.backward_rnn(x_reversed, mask=mask_reversed, is_sequential=is_sequential)
+        out_forward = self.forward_rnn(x, mask=mask)
+        out_backward = self.backward_rnn(x_reversed, mask=mask_reversed)
         concat = torch.cat((out_forward, out_backward.flip(dims=[1])), dim=2)
         out = self.linear(concat)
 

--- a/src/layers/rnn/MinGRU.py
+++ b/src/layers/rnn/MinGRU.py
@@ -10,8 +10,6 @@ class MinGRU(nn.Module):
         self.linear_z = nn.Linear(dim_in, dim_hidden)
         # Linear layer for producing candidate state h_tilde from x
         self.linear_h = nn.Linear(dim_in, dim_hidden)
-        self.dim_hidden = dim_hidden
-        self.dim_in = dim_in
 
     def parallel_scan_log(self, log_a, log_b, mask=None):
         """
@@ -55,20 +53,22 @@ class MinGRU(nn.Module):
         """
         return torch.where(x >= 0, torch.log(F.relu(x)+0.5), -F.softplus(-x))
 
-    def forward(self, x, *, mask=None, is_sequential = False):
+    def forward(self, x, *, h_prev=None, mask=None):
         """
-        Compute the forward pass. In sequential mode, we iterate over
-        the sequence length dimension, processing one token at a time.
-        In parallel mode, we process the tokens in parallel using the
-        parallel_scan_log algorithm. In both cases, we return one hidden
-        state for each token in the sequence. If mask is provided, mask 
-        out the hidden states corresponding to the True positions in the 
-        mask (this is used to mask out padding tokens in the sequence).
+        Compute the forward pass. Note that if h_prev is not none,
+        then we assume the model is processing tokens sequentially.
+        Otherwise, we enter parallel mode. In sequential mode,
+        the sequence length should be 1. In parallel mode, the
+        sequence length should be greater than 1. We return the
+        output of the RNN and the hidden state if return_hidden is True.
+
+        If mask is provided, mask out the hidden states corresponding to the True positions
+        in the mask (this is used to mask out padding tokens in the sequence).
 
         Args:
             x: torch.Tensor [batch_size, seq_len, dim_in]
+            h_prev (optional): torch.Tensor [batch_size, seq_len, dim_hidden]
             mask (optional): torch.Tensor [batch_size, seq_len]
-            is_sequential (optional): bool
         Returns:
             h: torch.Tensor [batch_size, seq_len, dim_hidden]
         """
@@ -78,28 +78,18 @@ class MinGRU(nn.Module):
         if mask is not None:
             mask = mask.unsqueeze(-1)
 
-        if is_sequential:  # Sequential mode
-            batch_size, seq_len, _ = x.shape
-            h_prev = torch.zeros(batch_size, self.dim_hidden).to(x.device)
-            h = torch.zeros(batch_size, 0, self.dim_hidden).to(x.device)
-
-            for t in range(seq_len): # Iterate over sequence length
-                k_t = k[:, t, :]
-                tilde_h_t = tilde_h[:, t, :]
-                z_t = torch.sigmoid(k_t)
-                tilde_h_t_p = self.g(tilde_h_t)
-                h_prev = ((1 - z_t) * h_prev) + (z_t * tilde_h_t_p)
-                if mask is not None:
-                    mask_t = mask.squeeze(-1)[:, t]
-                    h_prev = h_prev.masked_fill(mask_t.unsqueeze(-1), 0)
-                h = torch.cat((h, h_prev.unsqueeze(1)), dim=1)
+        if h_prev is not None:  # Sequential mode
+            assert x.shape[1] == 1
+            z = torch.sigmoid(k)
+            tilde_h = self.g(tilde_h)
+            h = ((1 - z) * h_prev) + (z * tilde_h)  # h[t]
         else:  # Parallel Mode
             # NOTE: the implementation provided in the paper allows providing an explicit
             #       starting state h_0; we fix h_0 (implicitly) to be zero initialized
             log_z = -F.softplus(-k)  # Log (z)
             log_one_minus_z = -F.softplus(k)  # Log (1 - z)
             log_tilde_h = self.log_g(tilde_h)  # Log candidate state
-
+  
             h = self.parallel_scan_log(
                 log_one_minus_z, log_z + log_tilde_h, mask)  # Hidden states
 

--- a/src/layers/rnn/MinGRU.py
+++ b/src/layers/rnn/MinGRU.py
@@ -79,7 +79,6 @@ class MinGRU(nn.Module):
             mask = mask.unsqueeze(-1)
 
         if h_prev is not None:  # Sequential mode
-            assert x.shape[1] == 1
             z = torch.sigmoid(k)
             tilde_h = self.g(tilde_h)
             h = ((1 - z) * h_prev) + (z * tilde_h)  # h[t]
@@ -92,7 +91,6 @@ class MinGRU(nn.Module):
   
             h = self.parallel_scan_log(
                 log_one_minus_z, log_z + log_tilde_h, mask)  # Hidden states
-
         if mask is not None:
             h = h.masked_fill(mask, 0)
         return h

--- a/src/layers/rnn/MinGRU.py
+++ b/src/layers/rnn/MinGRU.py
@@ -57,17 +57,15 @@ class MinGRU(nn.Module):
         """
         Compute the forward pass. Note that if h_prev is not none,
         then we assume the model is processing tokens sequentially.
-        Otherwise, we enter parallel mode. In sequential mode,
-        the sequence length should be 1. In parallel mode, the
-        sequence length should be greater than 1. We return the
+        Otherwise, we enter parallel mode. We return the
         output of the RNN and the hidden state if return_hidden is True.
 
         If mask is provided, mask out the hidden states corresponding to the True positions
         in the mask (this is used to mask out padding tokens in the sequence).
 
         Args:
-            x: torch.Tensor [batch_size, seq_len, dim_in]
-            h_prev (optional): torch.Tensor [batch_size, seq_len, dim_hidden]
+            x: torch.Tensor [batch_size, seq_len, dim_in] (parallel), [batch_size, dim_in] (sequential)
+            h_prev (optional): torch.Tensor [batch_size, dim_hidden]
             mask (optional): torch.Tensor [batch_size, seq_len]
         Returns:
             h: torch.Tensor [batch_size, seq_len, dim_hidden]
@@ -77,11 +75,10 @@ class MinGRU(nn.Module):
 
         if mask is not None:
             mask = mask.unsqueeze(-1)
-
         if h_prev is not None:  # Sequential mode
             z = torch.sigmoid(k)
             tilde_h = self.g(tilde_h)
-            h = ((1 - z) * h_prev) + (z * tilde_h)  # h[t]
+            h = ((1 - z) * h_prev) + (z * tilde_h)
         else:  # Parallel Mode
             # NOTE: the implementation provided in the paper allows providing an explicit
             #       starting state h_0; we fix h_0 (implicitly) to be zero initialized

--- a/src/layers/rnn/MinGRUBlock.py
+++ b/src/layers/rnn/MinGRUBlock.py
@@ -27,7 +27,10 @@ class MinGRUBlock(nn.Module):
         self.ln_2 = nn.LayerNorm(hidden_dim)
         self.ffn = FFN(hidden_dim, dropout)
 
-    def forward(self, x, mask=None, is_sequential=False):
-        x = x + self.minGRU(self.ln_1(x), mask=mask, is_sequential=is_sequential)
+    def forward(self, x, mask=None, h_prev=None):
+        h = self.minGRU(self.ln_1(x), mask=mask, h_prev=h_prev)
+        x = x + h
         x = x + self.ffn(self.ln_2(x))
+        if h_prev is not None:
+            return x, h
         return x

--- a/src/models/MinGRUSynthetic.py
+++ b/src/models/MinGRUSynthetic.py
@@ -1,3 +1,4 @@
+import torch
 from torch import nn
 from layers.rnn.MinGRUBlock import MinGRUBlock
 
@@ -5,7 +6,8 @@ from layers.rnn.MinGRUBlock import MinGRUBlock
 class MinGRUSynthetic(nn.Module):
     def __init__(self, *, vocab_size, embedding_dim, num_layers=1, bidirectional=False, num_classes):
         super().__init__()
-
+        self.num_layers = num_layers
+        self.embedding_dim = embedding_dim
         # Embedding layer
         self.embedding = nn.Embedding(vocab_size, embedding_dim)
         
@@ -17,8 +19,35 @@ class MinGRUSynthetic(nn.Module):
 
     def forward(self, x, mask=None, is_sequential=False):
         x = self.embedding(x)
-        for layer in self.layers:
-            x = layer(x, mask=mask, is_sequential=is_sequential)
-        x = self.linear(x[:, -1])
-
-        return x
+        if is_sequential: # Sequential
+            batch_size, seq_len, _ = x.shape
+            if not self.bidirectional: # Non bidirectional
+                h_prev = [torch.zeros(self.num_layers, batch_size, self.embedding_dim)] # (L, B, E)
+                for t in range(seq_len): # Iterate over the sequence length
+                    x_l = x[:, t, :] # (B, E)
+                    for layer_idx, layer in enumerate(self.layers): # For each token, iterate over the layers
+                        h_prev_l = h_prev[layer_idx] # (B, E)
+                        mask_t = mask[:, t] if mask is not None else None # (B)
+                        h_prev[layer_idx] = layer(x_l, mask=mask_t, h_prev=h_prev_l) 
+                return self.linear(h_prev[-1]) # (B, E)
+            
+            else: # Sequential & bidirectional
+                h_prev_forward = [torch.zeros(self.num_layers, batch_size, self.embedding_dim)]
+                h_prev_backward = [torch.zeros(self.num_layers, batch_size, self.embedding_dim)]
+                output = x # (B, S, E)
+                for t in range(seq_len):
+                    x_l_forward = output[:, t, :]
+                    x_l_backward = output[:, seq_len - 1 - t, :]
+                    next_output = []
+                    for layer_idx, layer in enumerate(self.layers):
+                        h_prev_forward_l = h_prev_forward[layer_idx]
+                        h_prev_backward_l = h_prev_backward[layer_idx]
+                        mask_forward_t = mask[:, t] if mask is not None else None
+                        mask_backward_t = mask[:, seq_len - 1 - t] if mask is not None else None
+                        out, h_prev_forward[layer_idx], h_prev_backward[layer_idx] = layer((x_l_forward, x_l_backward), mask=(mask_forward_t, mask_backward_t), h_prev=(h_prev_forward_l, h_prev_backward_l))
+                        next_output.append(out)
+                return self.linear(output[:, -1])
+        else: 
+            for layer in self.layers:
+                x = layer(x, mask=mask)
+            return self.linear(x[:, -1])

--- a/src/models/MinGRUSynthetic.py
+++ b/src/models/MinGRUSynthetic.py
@@ -22,14 +22,14 @@ class MinGRUSynthetic(nn.Module):
         if is_sequential: # Sequential
             assert not self.bidirectional, "Bidirectional not supported in sequential mode"
             batch_size, seq_len, _ = x.shape
-            h_prev = [torch.zeros(self.num_layers, batch_size, self.embedding_dim)] # (L, B, E)
-            for t in range(seq_len): # Iterate over the sequence length
-                x_l = x[:, t, :] # (B, E)
-                for layer_idx, layer in enumerate(self.layers): # For each token, iterate over the layers
-                    h_prev_l = h_prev[layer_idx] # (B, E)
-                    mask_t = mask[:, t] if mask is not None else None # (B)
-                    h_prev[layer_idx] = layer(x_l, mask=mask_t, h_prev=h_prev_l) 
-            return self.linear(h_prev[-1]) # (B, E)
+            h_prev = [torch.zeros(self.num_layers, batch_size, self.embedding_dim)] # (L, B, E), hidden states from previous token
+            for t in range(seq_len): # Iterate over tokens
+                x_l = x[:, t, :] # (B, E) Current token
+                for layer_idx, layer in enumerate(self.layers): # Iterate depthwise through the layers
+                    h_prev_l = h_prev[layer_idx] # (B, E) previous hidden state for current layer
+                    mask_t = mask[:, t] if mask is not None else None # (B) Mask for current token
+                    h_prev[layer_idx] = layer(x_l, mask=mask_t, h_prev=h_prev_l) # Update hidden state
+            return self.linear(h_prev[-1]) # (B, C) Output logits
         else: 
             for layer in self.layers:
                 x = layer(x, mask=mask)

--- a/src/models/MinGRUSynthetic.py
+++ b/src/models/MinGRUSynthetic.py
@@ -20,33 +20,16 @@ class MinGRUSynthetic(nn.Module):
     def forward(self, x, mask=None, is_sequential=False):
         x = self.embedding(x)
         if is_sequential: # Sequential
+            assert not self.bidirectional, "Bidirectional not supported in sequential mode"
             batch_size, seq_len, _ = x.shape
-            if not self.bidirectional: # Non bidirectional
-                h_prev = [torch.zeros(self.num_layers, batch_size, self.embedding_dim)] # (L, B, E)
-                for t in range(seq_len): # Iterate over the sequence length
-                    x_l = x[:, t, :] # (B, E)
-                    for layer_idx, layer in enumerate(self.layers): # For each token, iterate over the layers
-                        h_prev_l = h_prev[layer_idx] # (B, E)
-                        mask_t = mask[:, t] if mask is not None else None # (B)
-                        h_prev[layer_idx] = layer(x_l, mask=mask_t, h_prev=h_prev_l) 
-                return self.linear(h_prev[-1]) # (B, E)
-            
-            else: # Sequential & bidirectional
-                h_prev_forward = [torch.zeros(self.num_layers, batch_size, self.embedding_dim)]
-                h_prev_backward = [torch.zeros(self.num_layers, batch_size, self.embedding_dim)]
-                output = x # (B, S, E)
-                for t in range(seq_len):
-                    x_l_forward = output[:, t, :]
-                    x_l_backward = output[:, seq_len - 1 - t, :]
-                    next_output = []
-                    for layer_idx, layer in enumerate(self.layers):
-                        h_prev_forward_l = h_prev_forward[layer_idx]
-                        h_prev_backward_l = h_prev_backward[layer_idx]
-                        mask_forward_t = mask[:, t] if mask is not None else None
-                        mask_backward_t = mask[:, seq_len - 1 - t] if mask is not None else None
-                        out, h_prev_forward[layer_idx], h_prev_backward[layer_idx] = layer((x_l_forward, x_l_backward), mask=(mask_forward_t, mask_backward_t), h_prev=(h_prev_forward_l, h_prev_backward_l))
-                        next_output.append(out)
-                return self.linear(output[:, -1])
+            h_prev = [torch.zeros(self.num_layers, batch_size, self.embedding_dim)] # (L, B, E)
+            for t in range(seq_len): # Iterate over the sequence length
+                x_l = x[:, t, :] # (B, E)
+                for layer_idx, layer in enumerate(self.layers): # For each token, iterate over the layers
+                    h_prev_l = h_prev[layer_idx] # (B, E)
+                    mask_t = mask[:, t] if mask is not None else None # (B)
+                    h_prev[layer_idx] = layer(x_l, mask=mask_t, h_prev=h_prev_l) 
+            return self.linear(h_prev[-1]) # (B, E)
         else: 
             for layer in self.layers:
                 x = layer(x, mask=mask)

--- a/tests/test_BiMinGRU.py
+++ b/tests/test_BiMinGRU.py
@@ -28,6 +28,3 @@ class TestBiMinGRU:
         assert seq2_hidden_sequential.shape == seq2_hidden_batched.shape == (seq2_len, hidden_size)
         assert torch.allclose(seq1_hidden_batched, seq1_hidden_sequential, rtol=1e-4, atol=1e-6)
         assert torch.allclose(seq2_hidden_batched, seq2_hidden_sequential, rtol=1e-4, atol=1e-6)
-
-
-

--- a/tests/test_BiMinGRU.py
+++ b/tests/test_BiMinGRU.py
@@ -28,33 +28,6 @@ class TestBiMinGRU:
         assert seq2_hidden_sequential.shape == seq2_hidden_batched.shape == (seq2_len, hidden_size)
         assert torch.allclose(seq1_hidden_batched, seq1_hidden_sequential, rtol=1e-4, atol=1e-6)
         assert torch.allclose(seq2_hidden_batched, seq2_hidden_sequential, rtol=1e-4, atol=1e-6)
-    
-    def test_bi_min_gru_modes(self):
-        # Test parallel mode
-        layer = BiMinGRU(2, 3)
-        layer.eval()
-        batch = torch.randn(2, 3, 2) # BATCH_SIZE, SEQ_LEN, DIM_IN
 
-        output_parallel = layer(batch, is_sequential=False)
-        
-        # Test sequential mode
-        output_sequential = layer(batch, is_sequential=True)
-        assert torch.allclose(output_parallel, output_sequential, rtol=1e-4, atol=1e-6)
-    
-    def test_bi_min_gru_modes_masking(self):
-        # Test parallel mode
-        layer = BiMinGRU(2, 3)
-        layer.eval()
-        batch = torch.randn(2, 10, 2) # BATCH_SIZE, SEQ_LEN, DIM_IN
-
-        mask = torch.zeros((2, 10)).bool()
-        mask[0, 4:] = 1
-        mask[1, 3:] = 1
-
-        output_parallel = layer(batch, mask, is_sequential=False)
-        
-        # Test sequential mode
-        output_sequential = layer(batch, mask, is_sequential=True)
-        assert torch.allclose(output_parallel, output_sequential,  rtol=1e-4, atol=1e-6)
 
 

--- a/tests/test_MinGRUSynthetic.py
+++ b/tests/test_MinGRUSynthetic.py
@@ -32,6 +32,3 @@ class TestMinGRUSynthetic:
         out_parallel = model(x, is_sequential=False, mask=mask)
 
         assert torch.allclose(out_seq, out_parallel, rtol=1e-4, atol=1e-6)
-
-
-

--- a/tests/test_MinGRUSynthetic.py
+++ b/tests/test_MinGRUSynthetic.py
@@ -1,0 +1,37 @@
+from models.MinGRUSynthetic import MinGRUSynthetic
+import torch
+
+
+class TestMinGRUSynthetic:
+    def test_min_gru_synthetic(self):
+        batch_size, seq_len, embedding_dim = 2, 8, 4
+
+        model = MinGRUSynthetic(vocab_size=100, embedding_dim=embedding_dim, num_classes=4, num_layers=2, bidirectional=False)
+        model.eval()
+
+        x = torch.randint(0, 100, (batch_size, seq_len))
+
+        out_seq = model(x, is_sequential=True)
+        out_parallel = model(x, is_sequential=False)
+
+        assert torch.allclose(out_seq, out_parallel, rtol=1e-4, atol=1e-6)
+    
+    def test_min_gru_synthetic_mask(self):
+        batch_size, seq_len, embedding_dim = 2, 8, 4
+
+        model = MinGRUSynthetic(vocab_size=100, embedding_dim=embedding_dim, num_classes=4, num_layers=2, bidirectional=False)
+        model.eval()
+
+        x = torch.randint(0, 100, (batch_size, seq_len))
+        mask = torch.zeros((batch_size, seq_len))
+        mask[0, 2:] = 1
+        mask[1, 4:] = 1
+        mask = mask.bool()
+
+        out_seq = model(x, is_sequential=True, mask=mask)
+        out_parallel = model(x, is_sequential=False, mask=mask)
+
+        assert torch.allclose(out_seq, out_parallel, rtol=1e-4, atol=1e-6)
+
+
+

--- a/tests/test_mingru.py
+++ b/tests/test_mingru.py
@@ -1,7 +1,21 @@
 from layers.rnn.MinGRU import MinGRU
 import torch
 
-
 class TestMinGRU:
     def test_min_gru_modes(self):
-        return # TODO: Test sequential & parallel mode
+        batch_size, seq_len, embedding_dim = 2, 8, 4
+
+        model = MinGRU(dim_in=embedding_dim, dim_hidden=embedding_dim)
+        model.eval()
+
+        x = torch.randn((batch_size, seq_len, embedding_dim))
+
+        h_prev = torch.zeros((batch_size, embedding_dim))
+        out_sequential = torch.zeros((batch_size, seq_len, embedding_dim))
+        for i in range(seq_len):
+            h_prev = model(x[:, i], h_prev=h_prev)
+            out_sequential[:, i] = h_prev
+        
+        out_parallel = model(x)
+
+        assert torch.allclose(out_sequential, out_parallel, rtol=1e-4, atol=1e-6)

--- a/tests/test_mingru.py
+++ b/tests/test_mingru.py
@@ -4,15 +4,4 @@ import torch
 
 class TestMinGRU:
     def test_min_gru_modes(self):
-        # Test parallel mode
-        layer = MinGRU(3, 5)
-        layer.eval()
-        batch = torch.randn(4, 10, 3) # BATCH_SIZE, SEQ_LEN, DIM_IN
-        mask = torch.zeros((4, 10)).bool()
-        mask[0, 4:] = 1
-        mask[1, 3:] = 1
-        output_parallel = layer(batch, mask=mask, is_sequential=False)
-        
-        # Test sequential mode
-        output_sequential = layer(batch, mask=mask, is_sequential=True)
-        assert torch.allclose(output_parallel, output_sequential, rtol=1e-4, atol=1e-6)
+        return # TODO: Test sequential & parallel mode


### PR DESCRIPTION
Comments below should explain most of the PR, but I'll also add a quick note on why we don't need sequential more for bidirectionality:

I don't think we need to implement sequential mode in the bidirectional case because we can't get the memory optimization anyway (so there's no motivation to do sequential mode for bidirectionality). Specifically, we need the hidden states for each token in the forward pass & backward pass to concatenate them and pass them to the linear layer. Therefore, we need to store all of the hidden states, whereas in the sequential unidirectional case, we only need to store the hidden states for all of the layers for the previous token in the sequence (this is the memory optimization that becomes increasingly important as the sequence length becomes much longer than the number of layers).